### PR TITLE
Added option "flagnomiddlefoldingmark"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Option | Funktion
 --- | ---
 `german, english, spanish, swedish` | Lokalisierung der Labels und voreingestellten Anrede- und Grußformeln, beim Laden von *babel* wird entsprechende Option übergeben
 `nofoldingmark` | keine Falzmarkierung ausgeben
+`nomiddlefoldingmark` | nur die mittlere Falzmarkierung unterdrücken
 `justify` | Brieftext im Blocksatz anstatt linksbündig
 `fromheadernarrow` | gibt die Absenderinformationen als schmaleren Block aus
 

--- a/tfbrief.cls
+++ b/tfbrief.cls
@@ -92,6 +92,11 @@
   \renewcommand{\flagnofoldingmark}{yes}
 }
 
+\newcommand{\flagnomiddlefoldingmark}{}
+\DeclareOption{nomiddlefoldingmark}{%
+  \renewcommand{\flagnomiddlefoldingmark}{yes}
+}
+
 % use right-ragged (left-justified) text by default
 \newcommand{\textbodyalignment}{\RaggedRight}
 \DeclareOption{justify}{%
@@ -232,7 +237,9 @@
 \begin{picture}(0,0)%
 %% y-offset of 25 is required
 \put(-25,-81){\line(1,0){5}}%
-\put(-25,-124.5){\line(1,0){7}}%
+\ifthenelse{\equal{\flagnomiddlefoldingmark}{}}{
+  \put(-25,-124.5){\line(1,0){7}}%
+}{}%
 \put(-25,-186.5){\line(1,0){5}}%
 \end{picture}%
 }{}%


### PR DESCRIPTION
flagnomiddlefoldingmark will remove the long middle foldmark, but keep the two
smaller ones. Perfect if you usually only use Standard DIN C6/5
envelopes.

This is from an old tfbrief class I had on my machine for a loooong
time. I do not know where the original change came from.